### PR TITLE
Handling errors in requestFloat

### DIFF
--- a/protos/update.js
+++ b/protos/update.js
@@ -3,6 +3,7 @@ import https from 'https'
 
 const baseUrl = 'https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/csgo/'
 const protos = [
+  'engine_gcmessages.proto',
   'base_gcmessages.proto',
   'cstrike15_gcmessages.proto',
   'gcsdk_gcmessages.proto',

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,12 @@ class FloatClient extends EventEmitter {
   requestFloat (url) {
 
     if (!this._gcLoaded) { return this.emit('error', new Error('GC not loaded.')) }
-    if (!url) { return }
+    if (!url) { return q.reject('No URL specified.') }
+    if (typeof url !== 'string') { return q.reject('URL should be a string.') }
     if (this._defer && this._defer.promise.inspect().state === 'pending') { return q.reject('Request already in progress.') }
 
     const arr = url.match(/[SM]([0-9]*)A([0-9]*)D([0-9]*)/)
+    if (!arr) { return q.reject('Malformed URL.') }
 
     const firstS = url[0] === 'S'
     const param_s = firstS ? arr[1] : '0'


### PR DESCRIPTION
There are some cases in `requestFloat()` where some errors aren't processed. For example:
1) if the URI is malformed
2) if URI is not present (in this case, function returns `undefined`)
3) if URI is not a string

So I decided to fix this.
I wrote a simple script to test it:

```
var SteamTotp = require('steam-totp')
var FloatClient = require('csgo-float')

var login = "login"
var password = "password"
var shared = "shared"

const authCode = SteamTotp.getAuthCode(shared)

const logOnOptions = {
  account_name: login,
  password: password,
  two_factor_code: authCode,
}

const client = new FloatClient(logOnOptions, true)

client.on('ready', () => {
  var values = [null, false, undefined, true, 300, 'hello', 'S76561198190349706A4757476613D16467978012840927110']
  values.forEach(value => {
    try {
      console.log(`Trying ${value}`)
      client.requestFloat(value)
        .then(res => console.log(`Tried ${value}, success, result: ${res}`))
        .catch(err => console.log(`Tried ${value}, error: ${err}`))
    } catch (e) {
      console.log(`Error while getting value: ${e}`)
    }
  })
})

```

Here is the output for your version (irrelevant output omitted):

```
Trying null
Error while getting value: TypeError: Cannot read property 'then' of undefined
Trying false
Error while getting value: TypeError: Cannot read property 'then' of undefined
Trying undefined
Error while getting value: TypeError: Cannot read property 'then' of undefined
Trying true
Error while getting value: TypeError: url.match is not a function
Trying 300
Error while getting value: TypeError: url.match is not a function
Trying hello
Error while getting value: TypeError: Cannot read property '1' of null
Trying S76561198190349706A4757476613D16467978012840927110
[message] 5453
[message] 1
[message] 9157
[message] 5453
[message] 1
Tried S76561198190349706A4757476613D16467978012840927110, success, result: 0.060400836169719696
```

As you can see, it crashes every time when URL is not a valid string.
I've added some error handling and tried to run the same script, here are the results of my fixes:

```
Trying null
Trying false
Trying undefined
Trying true
Trying 300
Trying hello
Trying S76561198190349706A4757476613D16467978012840927110
[message] 5453
[message] 1
Tried null, error: No URL specified.
Tried false, error: No URL specified.
Tried undefined, error: No URL specified.
Tried true, error: URL should be a string.
Tried 300, error: URL should be a string.
Tried hello, error: Malformed URL.
[message] 5510
[message] 1
[message] 9157
[message] 5453
[message] 1
Tried S76561198190349706A4757476613D16467978012840927110, success, result: 0.060400836169719696
[message] 831
[message] 1
```

(Also I had to fix protos updating, because it didn't allow me to build a working version)
